### PR TITLE
feat: implement robust error handling with anyhow

### DIFF
--- a/hiverra-portal/Cargo.lock
+++ b/hiverra-portal/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +126,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 name = "portal"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "clap",
 ]
 

--- a/hiverra-portal/Cargo.toml
+++ b/hiverra-portal/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2024"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive"] }
-
+anyhow = "1.0"

--- a/hiverra-portal/src/commands.rs
+++ b/hiverra-portal/src/commands.rs
@@ -1,6 +1,9 @@
 use clap::Subcommand;
 use std::path::PathBuf;
 
+// Import anyhow to handle errors without crashing
+use anyhow::{Context, Result};
+
 use crate::receiver::receive_file;
 use crate::sender::send_file;
 
@@ -19,10 +22,18 @@ pub enum Commands {
 impl Commands {
     // This is the method attached to the Enum
     // pub is needed here also to be able to call the function
-    pub fn execute(&self) {
+    // We now return Result<()> to catch errors from sender/receiver
+    pub fn execute(&self) -> Result<()> {
         match self {
-            Commands::Send { file } => send_file(&file),
-            Commands::Receive => receive_file(),
+            Commands::Send { file } => {
+                // Pass the error up if sending fails
+                send_file(&file).context("Failed to execute Send command")?;
+            }
+            Commands::Receive => {
+                // Pass the error up if receiving fails
+                receive_file().context("Failed to execute Receive command")?;
+            }
         }
+        Ok(()) // Return success if no errors occurred
     }
 }

--- a/hiverra-portal/src/main.rs
+++ b/hiverra-portal/src/main.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use std::process::exit;
 
 mod commands; // Links the commands file
 use commands::Commands; // Using the 'pub' enum and fn
@@ -18,6 +19,15 @@ struct Cli {
 fn main() {
     // 3. Parse the user's input
     let cli = Cli::parse();
+
     // 4. Act on the input
-    cli.command.execute();
+    // Since execute() now returns a Result, we check if it's an Error (Err)
+    if let Err(e) = cli.command.execute() {
+        // eprint! prints to the 'Standard Error' stream instead of 'Standard Output'
+        // {:?} prints the error message plus all the .context() notes we added
+        eprintln!("Portal Error: {:#}", e);
+
+        // Exit with a non-zero code to tell the OS that the program failed
+        exit(1);
+    }
 }

--- a/hiverra-portal/src/receiver.rs
+++ b/hiverra-portal/src/receiver.rs
@@ -4,12 +4,15 @@ use std::{
     net::TcpListener,
 };
 
-pub fn receive_file() {
+// Import anyhow for add descriptive error handling
+use anyhow::{Context, Result};
+
+pub fn receive_file() -> Result<()> {
     println!("Portal: Initializing  systems...");
-    let listener = TcpListener::bind("127.0.0.1:7878").expect("Failed to bind to port 7878");
+    let listener = TcpListener::bind("127.0.0.1:7878").context("Failed to bind to port 7878")?;
 
     println!("Receiver: Portal open. Waiting for a connection on port 7878...");
-    let (mut socket, addr) = listener.accept().expect("Failed to accept connection");
+    let (mut socket, addr) = listener.accept().context("Failed to accept connection")?;
     println!("Receiver: Connection established with {}!", addr);
     println!("Portal: Connected to sender");
     println!("Portal: Waiting for incoming files...");
@@ -18,12 +21,14 @@ pub fn receive_file() {
     let mut name_len_buf = [0u8; 4];
     socket
         .read_exact(&mut name_len_buf)
-        .expect("Failed to read name length"); // Read exactly 4 bytes
+        .context("Failed to read name length")?; // Read exactly 4 bytes
     let name_len = u32::from_be_bytes(name_len_buf); // Turn bytes back into a number
 
     // 2. Read the actual name
     let mut name_buf = vec![0u8; name_len as usize];
-    socket.read_exact(&mut name_buf);
+    socket
+        .read_exact(&mut name_buf)
+        .context("Failed to read the filename from the stream")?;
     let filename = String::from_utf8_lossy(&name_buf);
 
     println!("Receiving file: {}", filename);
@@ -32,28 +37,32 @@ pub fn receive_file() {
     let mut size_buf = [0u8; 8];
     socket
         .read_exact(&mut size_buf)
-        .expect("Failed to read size");
+        .context("Failed to read size")?;
     let file_size = u64::from_be_bytes(size_buf);
 
     // 4. Create the file on disk
     // We use &*filename to tell Cow to act like a normal string
-    let mut out_file = File::create(&*filename).expect("Failed to create file");
+    let mut out_file = File::create(&*filename).context("Failed to create file on disk")?;
 
     // 5. The loop to actually save the bytes
     let mut buffer = [0u8; 8192];
     let mut received_so_far = 0;
 
     while received_so_far < file_size {
-        let bytes_read = socket.read(&mut buffer).expect("Network read error");
+        let bytes_read = socket
+            .read(&mut buffer)
+            .context("Network read error during file transfer")?;
         if bytes_read == 0 {
             break;
         } // Sender hung up
 
         out_file
             .write_all(&buffer[..bytes_read])
-            .expect("Disk write error");
+            .context("Disk write error")?;
         received_so_far += bytes_read as u64;
     }
 
     println!("Portal: Transfer complete! Saved as {}", filename);
+
+    Ok(())
 }


### PR DESCRIPTION
- Replaces all instances of .expect() and manual println! error reporting with a unified anyhow::Result architecture.
- Updates main.rs, commands.rs, sender.rs, and receiver.rs to support Result<()> return types.
- Adds descriptive .context() calls to all I/O and Network operations for better debugging.
- Implements proper stderr reporting using eprintln! and single-line error chains ({:#}).
- Preserved all existing logic documentation and comments.
