### PR TITLE
feat: implement global networking and automatic IP discovery

### DIFF
--- a/hiverra-portal/Cargo.lock
+++ b/hiverra-portal/Cargo.lock
@@ -68,6 +68,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +140,24 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "libc"
+version = "0.2.180"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+
+[[package]]
+name = "network-interface"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddcb8865ad3d9950f22f42ffa0ef0aecbfbf191867b3122413602b0a360b2a6"
+dependencies = [
+ "cc",
+ "libc",
+ "thiserror",
+ "winapi",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -138,6 +172,7 @@ dependencies = [
  "anyhow",
  "bincode",
  "clap",
+ "network-interface",
  "serde",
 ]
 
@@ -190,6 +225,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +248,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +278,28 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/hiverra-portal/Cargo.toml
+++ b/hiverra-portal/Cargo.toml
@@ -5,7 +5,8 @@ authors = ["Spectra010s"]
 edition = "2024"
 
 [dependencies]
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 anyhow = "1.0"
 serde = { version = "1.0.228", features = ["derive"] }
 bincode = "1.3.3"
+network-interface = "2.0.5"

--- a/hiverra-portal/src/commands.rs
+++ b/hiverra-portal/src/commands.rs
@@ -14,6 +14,9 @@ pub enum Commands {
     /// Send a file
     Send {
         file: PathBuf, // changed it to PathBuf, so as to hold "File System Object".
+        /// The IP address of the receiver (e.g., 192.168.1.5)
+        #[arg(short, long)]
+        address: String,
     },
     /// Receive a file
     Receive,
@@ -25,9 +28,9 @@ impl Commands {
     // We now return Result<()> to catch errors from sender/receiver
     pub fn execute(&self) -> Result<()> {
         match self {
-            Commands::Send { file } => {
+            Commands::Send { file, address } => {
                 // Pass the error up if sending fails
-                send_file(&file).context("Failed to execute Send command")?;
+                send_file(&file, &address).context("Failed to execute Send command")?;
             }
             Commands::Receive => {
                 // Pass the error up if receiving fails

--- a/hiverra-portal/src/sender.rs
+++ b/hiverra-portal/src/sender.rs
@@ -30,7 +30,7 @@ fn create_metadata(file: &PathBuf, desc: Option<String>) -> anyhow::Result<FileM
     })
 }
 
-pub fn send_file(file: &PathBuf) -> Result<()> {
+pub fn send_file(file: &PathBuf, addr: &str) -> Result<()> {
     // Check 1. check if the path exists before attempting to send
     if !file.exists() {
         println!("Error: The file '{}' does not exist.", file.display());
@@ -98,9 +98,9 @@ pub fn send_file(file: &PathBuf) -> Result<()> {
         let mut reader = BufReader::new(file_handle);
 
         println!("Portal: Buffer initialized and ready for streaming.");
-
-        let mut stream =
-            TcpStream::connect("127.0.0.1:7878").context("Could not connect to Reciever!")?;
+        let r_addr = format!("{}:7878", addr);
+        println!("Portal: connecting to {}", r_addr);
+        let mut stream = TcpStream::connect(r_addr).context("Could not connect to Reciever!")?;
         println!("Sender: Connected to receiver!");
 
         // 3. Stream the Metadata to the Pipe


### PR DESCRIPTION
- Added a new `--address` (-a) flag to the Send command to allow remote connections.
- Integrated `network-interface` crate for hardware-level IP detection.
- Added `get_local_ip()` using functional iterators (flat_map/find) to auto-detect host IP.
- Bound Receiver to `0.0.0.0` to listen for incoming connections across the network.

> [!Note]: IP discovery logic is tailored for Termux/Android but requires testing
to ensure it prioritizes the correct interface (Hotspot vs. Cellular).
**Also, tests on windows are needed urgently**
