### PR TITLE
fix: resolve type mismatches and unused imports in update logic

### DIFF
--- a/hiverra-portal/Cargo.lock
+++ b/hiverra-portal/Cargo.lock
@@ -668,7 +668,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hiverra-portal"
-version = "0.5.0-alpha"
+version = "0.5.1-alpha"
 dependencies = [
  "anyhow",
  "bincode",

--- a/hiverra-portal/Cargo.toml
+++ b/hiverra-portal/Cargo.toml
@@ -1,13 +1,12 @@
 [package]
 name = "hiverra-portal"
-version = "0.5.0-alpha"
+version = "0.5.1-alpha"
 authors = ["Spectra010s <spectra010s@gmail.com"]
 edition = "2024"
 repository = "https://github.com/Spectra010s/portal" 
 description = "Portal is a lightweight, cross-platform CLI tool built in Rust for sending files and folders between devices instantly."
 homepage = "https://github.com/Spectra010s/portal"
 license = "MIT"
-
 
 [package.metadata.wix]
 product-name = "Hiverra Portal"


### PR DESCRIPTION
- Explicitly define closure return types for spawn_blocking tasks
- Move Windows-specific imports behind #[cfg] attributes
- Fix '?' operator usage by ensuring Result return in update closures
- Clean up unreachable code warnings on Windows target
