### PR TITLE
feat: integrate inquire for interactive user flow

### DIFF
--- a/hiverra-portal/Cargo.lock
+++ b/hiverra-portal/Cargo.lock
@@ -637,7 +637,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hiverra-portal"
-version = "0.5.1-beta.2"
+version = "0.6.0-rc.1"
 dependencies = [
  "anyhow",
  "bincode",

--- a/hiverra-portal/Cargo.toml
+++ b/hiverra-portal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiverra-portal"
-version = "0.5.1-beta.2"
+version = "0.6.0-rc.1"
 authors = ["Spectra010s <spectra010s@gmail.com"]
 edition = "2024"
 repository = "https://github.com/Spectra010s/portal" 

--- a/hiverra-portal/src/main.rs
+++ b/hiverra-portal/src/main.rs
@@ -5,8 +5,10 @@ mod commands; // Links the commands file
 use commands::Commands; // Using the 'pub' enum and fn
 mod metadata;
 mod receiver;
+mod select;
 mod sender;
 mod update;
+
 // 1. Defining the Map (The Struct)
 #[derive(Parser)]
 #[command(name = "portal")]

--- a/hiverra-portal/src/select.rs
+++ b/hiverra-portal/src/select.rs
@@ -1,0 +1,39 @@
+use anyhow::{Context, Result};
+use inquire::Select;
+use tokio::fs::read_dir;
+
+pub async fn select_file_to_send() -> Result<Option<String>> {
+    // 1. Open the current directory
+    let mut entries = read_dir(".").await.context("Failed to read directory")?;
+    let mut files = Vec::new();
+
+    // 2. Collect file names into the vector
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let path = entry.path();
+
+        if let Ok(file_metadata) = entry.metadata().await {
+            if file_metadata.is_file() {
+                // Safely get the file name
+                if let Some(name) = path.file_name() {
+                    files.push(name.to_string_lossy().into_owned());
+                }
+            }
+        }
+    }
+
+    // 3. Handle empty directory
+    if files.is_empty() {
+        println!("Portal: No files found in the current directory.");
+        return Ok(None);
+    }
+
+    // 4. Show the interactive picker
+    // Inquire handles the terminal UI logic here
+    match Select::new("Select a file to send:", files).prompt() {
+        Ok(choice) => Ok(Some(choice)),
+        Err(_) => {
+            println!("Portal: Selection cancelled.");
+            Ok(None)
+        }
+    }
+}


### PR DESCRIPTION
- Implemented interactive file picker for the `Send` command.
- Replaced manual Stdin/out with `inquire` prompts for file descriptions.
- Made `file` and `address` arguments optional; added fallback prompting if omitted.
- Streamlined command execution logic to handle dynamic user input.
