### PR TITLE
fix(web): correct portal domain in install links

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ portal update
 - Default log file level is `debug`.
 - Logs are written to `~/.portal/_logs/`.
 - `PORTAL_LOG` is preferred over `RUST_LOG` when both are set.
-- For troubleshooting noisy or missing logs, see [Troubleshooting](https://portal.build.app/docs/troubleshooting).
+- For troubleshooting noisy or missing logs, see [Troubleshooting](https://portal.biuld.app/docs/troubleshooting).
 
 ## How to Run or Use It
 
@@ -235,12 +235,12 @@ portal config list
 
 Detailed guides for every workflow:
 
-- [Docs Home](https://portal.build.app/docs)
-- [Install](https://portal.build.app/docs/install)
-- [Usage](https://portal.build.app/docs/usage)
-- [CLI to CLI](https://portal.build.app/docs/cli-cli)
-- [Troubleshooting](https://portal.build.app/docs/troubleshooting)
-- [FAQ](https://portal.build.app/docs/faq)
+- [Docs Home](https://portal.biuld.app/docs)
+- [Install](https://portal.biuld.app/docs/install)
+- [Usage](https://portal.biuld.app/docs/usage)
+- [CLI to CLI](https://portal.biuld.app/docs/cli-cli)
+- [Troubleshooting](https://portal.biuld.app/docs/troubleshooting)
+- [FAQ](https://portal.biuld.app/docs/faq)
 
 Docs source of truth:
 

--- a/apps/web/app/docs/opengraph-image.tsx
+++ b/apps/web/app/docs/opengraph-image.tsx
@@ -106,7 +106,7 @@ export default function Image() {
             color: "#475569",
           }}
         >
-          <span style={{ display: "flex" }}>portal.build.app/docs</span>
+          <span style={{ display: "flex" }}>portal.biuld.app/docs</span>
           <span
             style={{
               display: "flex",

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -10,7 +10,7 @@ export const contentType = "image/png";
 
 export default function Image() {
   const site = (
-    process.env.NEXT_PUBLIC_SITE_URL || "https://portal.build.app"
+    process.env.NEXT_PUBLIC_SITE_URL || "https://portal.biuld.app"
   ).replace(/^https?:\/\//, "");
 
   return new ImageResponse(

--- a/apps/web/components/Terminal.tsx
+++ b/apps/web/components/Terminal.tsx
@@ -7,17 +7,17 @@ const installers = [
   {
     id: "linux",
     label: "Linux / macOS",
-    cmd: "curl -fsSL https://portal.build.app/install.sh | sh",
+    cmd: "curl -fsSL https://portal.biuld.app/install.sh | sh",
   },
   {
     id: "android",
     label: "Android / Termux",
-    cmd: "curl -fsSL https://portal.build.app/install.sh | sh",
+    cmd: "curl -fsSL https://portal.biuld.app/install.sh | sh",
   },
   {
     id: "windows",
     label: "PowerShell",
-    cmd: 'powershell -ExecutionPolicy Bypass -c "irm https://portal.build.app/install.ps1 | iex"',
+    cmd: 'powershell -ExecutionPolicy Bypass -c "irm https://portal.biuld.app/install.ps1 | iex"',
   },
   { id: "npm", label: "npm", cmd: "npm install -g @hiverra/portal@0.11.1" },
 ];

--- a/apps/web/content/install.mdx
+++ b/apps/web/content/install.mdx
@@ -22,7 +22,7 @@ There are several ways to install Portal, but they are not equal. If you just wa
 Use the installer script:
 
 ```bash
-curl -fsSL https://portal.build.app/install.sh | sh
+curl -fsSL https://portal.biuld.app/install.sh | sh
 ```
 
 ### Windows
@@ -30,7 +30,7 @@ curl -fsSL https://portal.build.app/install.sh | sh
 Use the PowerShell installer:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://portal.build.app/install.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://portal.biuld.app/install.ps1 | iex"
 ```
 
 ### Android / Termux
@@ -38,7 +38,7 @@ powershell -ExecutionPolicy Bypass -c "irm https://portal.build.app/install.ps1 
 Use the Android-specific installer:
 
 ```bash
-curl -fsSL https://portal.build.app/install.sh | sh
+curl -fsSL https://portal.biuld.app/install.sh | sh
 ```
 
 ### npm package


### PR DESCRIPTION
- update install/docs links from portal.build.app to portal.biuld.app
- fix visible installer commands and OG site text/fallbacks