### PR TITLE
feat(discovery): add broadcast fallback, closes #109

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ permissions:
   contents: write
 
 on:
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
@@ -191,7 +190,7 @@ jobs:
           $hash = (Get-FileHash "$dist/$package.zip" -Algorithm SHA256).Hash.ToLower()
           "$hash  $package.zip" | Set-Content "$dist/$package.zip.sha256"
 
-          cargo wix --no-build --target x86_64-pc-windows-msvc --input wix/main.wxs --output "$dist/$package.msi"
+          cargo wix --no-build --target x86_64-pc-windows-msvc --target-bin-dir "target/x86_64-pc-windows-msvc/release" --output "$dist/$package.msi" wix/main.wxs
           $msiHash = (Get-FileHash "$dist/$package.msi" -Algorithm SHA256).Hash.ToLower()
           "$msiHash  $package.msi" | Set-Content "$dist/$package.msi.sha256"
 

--- a/src/discovery/beacon.rs
+++ b/src/discovery/beacon.rs
@@ -1,9 +1,11 @@
 use {
-    crate::discovery::protocol::PortalBeacon,
+    crate::discovery::protocol::{DISCOVERY_PORT, MULTICAST_ADDR, PROTOCOL_NAME, PortalBeacon},
     anyhow::Result,
+    network_interface::{Addr, NetworkInterface, NetworkInterfaceConfig},
+    std::collections::BTreeSet,
     std::time::Duration,
     tokio::net::UdpSocket,
-    tracing::{debug, info, trace},
+    tracing::{debug, info, trace, warn},
 };
 
 pub async fn start_beacon(username: String, node_id: String, tcp_port: u16) -> Result<()> {
@@ -12,11 +14,15 @@ pub async fn start_beacon(username: String, node_id: String, tcp_port: u16) -> R
     // bind anywhere
     trace!("Binding discovery UDP socket to 0.0.0.0:0");
     let socket = UdpSocket::bind("0.0.0.0:0").await?;
-    let target_addr = "224.0.0.123:5005";
-    trace!("Multicast target address set to: {}", target_addr);
+    socket.set_broadcast(true)?;
+
+    let multicast_target = format!("{}:{}", MULTICAST_ADDR, DISCOVERY_PORT);
+    let broadcast_targets = broadcast_targets();
+    trace!("Multicast target address set to: {}", multicast_target);
+    debug!("Broadcast target addresses set to: {:?}", broadcast_targets);
 
     let beacon = PortalBeacon {
-        protocol: "portal".to_string(),
+        protocol: PROTOCOL_NAME.to_string(),
         node_id,
         username,
         port: tcp_port,
@@ -30,9 +36,51 @@ pub async fn start_beacon(username: String, node_id: String, tcp_port: u16) -> R
     );
 
     loop {
-        // sends to the multicast address
-        trace!("Broadcasting discovery heartbeat...");
-        socket.send_to(&msg, target_addr).await?;
+        trace!("Sending multicast discovery heartbeat...");
+        socket.send_to(&msg, &multicast_target).await?;
+
+        for target_addr in &broadcast_targets {
+            trace!("Sending broadcast discovery heartbeat to {}...", target_addr);
+            if let Err(err) = socket.send_to(&msg, target_addr).await {
+                warn!("Failed to send broadcast discovery heartbeat: {}", err);
+            }
+        }
+
         tokio::time::sleep(Duration::from_secs(1)).await;
     }
+}
+
+fn broadcast_targets() -> Vec<String> {
+    let mut targets = BTreeSet::new();
+
+    match NetworkInterface::show() {
+        Ok(interfaces) => {
+            for interface in interfaces {
+                if interface.internal {
+                    continue;
+                }
+
+                for addr in interface.addr {
+                    if let Addr::V4(ifaddr) = addr {
+                        if ifaddr.ip.is_loopback() {
+                            continue;
+                        }
+
+                        if let Some(broadcast) = ifaddr.broadcast {
+                            targets.insert(format!("{}:{}", broadcast, DISCOVERY_PORT));
+                        }
+                    }
+                }
+            }
+        }
+        Err(err) => {
+            debug!("Could not inspect network interfaces for broadcast targets: {}", err);
+        }
+    }
+
+    if targets.is_empty() {
+        targets.insert(format!("255.255.255.255:{}", DISCOVERY_PORT));
+    }
+
+    targets.into_iter().collect()
 }

--- a/src/discovery/listener.rs
+++ b/src/discovery/listener.rs
@@ -1,5 +1,5 @@
 use {
-    crate::discovery::protocol::PortalBeacon,
+    crate::discovery::protocol::{DISCOVERY_PORT, MULTICAST_ADDR, PROTOCOL_NAME, PortalBeacon},
     anyhow::Result,
     socket2::{Domain, Protocol, Socket, Type},
     std::net::{Ipv4Addr, SocketAddr},
@@ -7,9 +7,29 @@ use {
     tracing::{debug, info, trace},
 };
 
-pub async fn find_receiver(target_username: &str) -> Result<(String, String, u16)> {
+#[derive(Debug, Clone, Copy)]
+pub enum DiscoveryMode {
+    Multicast,
+    Broadcast,
+}
+
+pub async fn find_receiver_multicast(target_username: &str) -> Result<(String, String, u16)> {
+    find_receiver(target_username, DiscoveryMode::Multicast).await
+}
+
+pub async fn find_receiver_broadcast(target_username: &str) -> Result<(String, String, u16)> {
+    find_receiver(target_username, DiscoveryMode::Broadcast).await
+}
+
+async fn find_receiver(
+    target_username: &str,
+    mode: DiscoveryMode,
+) -> Result<(String, String, u16)> {
     // create the low-level socket for OS port-sharing
-    trace!("Creating raw UDP socket for discovery (port sharing enabled)");
+    trace!(
+        "Creating raw UDP socket for {:?} discovery (port sharing enabled)",
+        mode
+    );
     let raw_socket = Socket::new(Domain::IPV4, Type::DGRAM, Some(Protocol::UDP))?;
 
     trace!("Setting SO_REUSEADDR on discovery socket");
@@ -20,7 +40,7 @@ pub async fn find_receiver(target_username: &str) -> Result<(String, String, u16
         raw_socket.set_reuse_port(true)?;
     }
 
-    let address: SocketAddr = "0.0.0.0:5005".parse()?;
+    let address: SocketAddr = format!("0.0.0.0:{}", DISCOVERY_PORT).parse()?;
     raw_socket.set_nonblocking(true)?;
     trace!("Binding discovery socket to {}", address);
     raw_socket.bind(&address.into())?;
@@ -29,19 +49,20 @@ pub async fn find_receiver(target_username: &str) -> Result<(String, String, u16
     let std_socket: std::net::UdpSocket = raw_socket.into();
     let socket = UdpSocket::from_std(std_socket)?;
 
-    // join the multicast group
-    let multicast_addr = Ipv4Addr::new(224, 0, 0, 123);
-    trace!("Joining multicast group: {}", multicast_addr);
-    socket.join_multicast_v4(multicast_addr, Ipv4Addr::UNSPECIFIED)?;
+    if let DiscoveryMode::Multicast = mode {
+        let multicast_addr: Ipv4Addr = MULTICAST_ADDR.parse()?;
+        trace!("Joining multicast group: {}", multicast_addr);
+        socket.join_multicast_v4(multicast_addr, Ipv4Addr::UNSPECIFIED)?;
+    }
 
     let mut buf = [0u8; 1024];
 
-    trace!("Entering discovery loop, waiting for beacon...");
+    trace!("Entering {:?} discovery loop, waiting for beacon...", mode);
     loop {
         let (len, remote_addr) = socket.recv_from(&mut buf).await?;
         trace!(
-            "Received packet on port 5005 (size: {} bytes, from: {})",
-            len, remote_addr
+            "Received packet on port {} (size: {} bytes, from: {})",
+            DISCOVERY_PORT, len, remote_addr
         );
 
         if let Ok(beacon) = serde_json::from_slice::<PortalBeacon>(&buf[..len]) {
@@ -50,18 +71,20 @@ pub async fn find_receiver(target_username: &str) -> Result<(String, String, u16
                 beacon.protocol, beacon.username
             );
             // check if this is the person we are looking for
-            if beacon.protocol == "portal" {
+            if beacon.protocol == PROTOCOL_NAME {
                 if beacon.username == target_username {
                     info!(
-                        "Portal: Found receiver '{}' at {}!",
+                        "Portal: Found receiver '{}' at {} via {:?} discovery!",
                         beacon.username,
-                        remote_addr.ip()
+                        remote_addr.ip(),
+                        mode
                     );
                     debug!(
-                        "Beacon match found: IP={}, ID={}, Port={}",
+                        "Beacon match found: IP={}, ID={}, Port={}, Mode={:?}",
                         remote_addr.ip(),
                         beacon.node_id,
-                        beacon.port
+                        beacon.port,
+                        mode
                     );
 
                     // return (IP, Node_ID, Port)

--- a/src/discovery/protocol.rs
+++ b/src/discovery/protocol.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+pub const DISCOVERY_PORT: u16 = 5005;
+pub const MULTICAST_ADDR: &str = "224.0.0.123";
+pub const PROTOCOL_NAME: &str = "portal";
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PortalBeacon {
     pub protocol: String,

--- a/src/sender/handshake.rs
+++ b/src/sender/handshake.rs
@@ -1,5 +1,5 @@
 use {
-    crate::discovery::listener::find_receiver,
+    crate::discovery::listener::{find_receiver_broadcast, find_receiver_multicast},
     anyhow::{Context, Result, anyhow},
     inquire::Text,
     std::time::Duration,
@@ -32,12 +32,37 @@ pub async fn connect_and_verify(
         info!("Discovery started for user: {}", target_username);
         peer_username = Some(target_username.clone());
 
-        let discovery_result = timeout(
+        let discovery_result = match timeout(
             Duration::from_secs(30),
-            find_receiver(&target_username),
+            find_receiver_multicast(&target_username),
         )
         .await
-        .context("Portal: Search timed out. Make sure the receiver is active and on the same network.")??;
+        {
+            Ok(result) => result.context("Portal: Multicast discovery failed.")?,
+            Err(_) => {
+                warn!("Multicast discovery timed out for user: {}", target_username);
+                warn!("Trying subnet broadcast discovery for user: {}", target_username);
+
+                match timeout(
+                    Duration::from_secs(30),
+                    find_receiver_broadcast(&target_username),
+                )
+                .await
+                {
+                    Ok(result) => result.context("Portal: Broadcast discovery failed.")?,
+                    Err(_) => {
+                        warn!("Broadcast discovery timed out for user: {}", target_username);
+                        return Err(anyhow!(
+                            "Portal: Search timed out. Make sure the receiver is active and on the same network.\n\
+                             Portal: Try direct address mode:\n\
+                             Portal:   portal send --address <receiver-ip> --port {} <file-or-folder>\n\
+                             Tip: The receiver shows its listening address when running `portal receive`.",
+                            port
+                        ));
+                    }
+                }
+            }
+        };
 
         let (ip, id, p) = discovery_result;
         info!("Receiver found at {}:{} (Node ID: {})", ip, p, id);


### PR DESCRIPTION
- emit broadcast discovery beacons alongside multicast beacons
- try multicast discovery first, then broadcast when multicast times out
- return direct-address guidance when both discovery paths fail
- fix Windows MSI packaging in the release workflow
