### PR TITLE
fix(ci): grant workflow write permissions and add self-healing hash detection

### DIFF
--- a/.github/workflows/changelog-updater.yml
+++ b/.github/workflows/changelog-updater.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   update-changelog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: github.repository == 'Spectra010s/portal'
     steps:
       - name: Checkout Repository

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -76,10 +76,23 @@ async function main() {
     process.exit(1);
   }
 
-  // Get commit range from GitHub event
-  const before = process.env.COMMIT_BEFORE;
+  // Determine starting commit hash (before)
+  let before = process.env.COMMIT_BEFORE;
   const after = process.env.COMMIT_AFTER || 'HEAD';
   const repo = process.env.GITHUB_REPOSITORY || 'Spectra010s/portal';
+
+  try {
+    if (fs.existsSync('CHANGELOG.md')) {
+      const changelogContent = fs.readFileSync('CHANGELOG.md', 'utf8');
+      const match = changelogContent.match(/\[\[([a-f0-9]{7,})\]\]/);
+      if (match) {
+        before = match[1];
+        console.log(`Self-healing: Found last processed commit hash in CHANGELOG.md: ${before}`);
+      }
+    }
+  } catch (err) {
+    console.log("Could not parse CHANGELOG.md for a starting hash.");
+  }
   
   console.log(`Resolving commit range: before=${before}, after=${after}, repo=${repo}`);
   


### PR DESCRIPTION
This PR fixes the 403 Permission Denied error during the changelog automated commit and adds a self-healing mechanism to ensure no commits are skipped when the action fails.