### PR TITLE
feat(cli): stage received files and resolve conflicts after transfer — Closes #160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,15 @@ All notable changes to this project will be documented in this file, structured 
 
 ## [Unreleased]
 
-- **docs(release)**: bump v0.12.0 references to v0.13.0 and cut changelog [[06b74b4](https://github.com/Spectra010s/portal/commit/06b74b4)]
+---
+
+## [v0.14.0] - 2026-08-17
+
+- **docs(release)**: bump v0.13.0 references to v0.14.0 and cut changelog (#161)
+- **feat(cli)**: stage received files and resolve conflicts after transfer (#161) [[7bfa787](https://github.com/Spectra010s/portal/commit/7bfa787)]
+- **docs**: document staged receive, post-transfer conflicts, and draft streaming-01 (#161) [[7a17927](https://github.com/Spectra010s/portal/commit/7a17927)]
 - **ci(release)**: Revert one-time workflow_dispatch trigger [[8b4e51f](https://github.com/Spectra010s/portal/commit/8b4e51f)]
+- **docs(release)**: bump v0.12.0 references to v0.13.0 and cut changelog [[06b74b4](https://github.com/Spectra010s/portal/commit/06b74b4)]
 
 ---
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["pxp", "portal-cli"]
 resolver = "3"
 
 [workspace.dependencies]
-pxp = { path = "pxp", version = "0.1.0" }
+pxp = { path = "pxp", version = "0.2.0" }
 serde = { version = "1.0.228", features = ["derive"] }
 bincode = "1.3.3"
 tokio = { version = "1.49.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -31,25 +31,25 @@ Portal is for anyone who wants a fast, local, no-fuss way to move files between 
 **Shell script (Linux/macOS/Android)**
 
 ```bash
-curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Spectra010s/portal/releases/download/v0.13.0/hiverra-portal-installer.sh | sh
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/Spectra010s/portal/releases/download/v0.14.0/hiverra-portal-installer.sh | sh
 ```
 
 **PowerShell (Windows)**
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://github.com/Spectra010s/portal/releases/download/v0.13.0/hiverra-portal-installer.ps1 | iex"
+powershell -ExecutionPolicy Bypass -c "irm https://github.com/Spectra010s/portal/releases/download/v0.14.0/hiverra-portal-installer.ps1 | iex"
 ```
 
 **npm (prebuilt binaries)**
 
 ```bash
-npm install -g @hiverra/portal@0.13.0
+npm install -g @hiverra/portal@0.14.0
 ```
 
 **Android / Termux**
 
 ```bash
-curl -LsSf https://github.com/Spectra010s/portal/releases/download/v0.13.0/hiverra-portal-installer.sh | sh
+curl -LsSf https://github.com/Spectra010s/portal/releases/download/v0.14.0/hiverra-portal-installer.sh | sh
 ```
 
 **Direct download**

--- a/apps/web/app/(home)/page.tsx
+++ b/apps/web/app/(home)/page.tsx
@@ -56,7 +56,7 @@ export default function Home() {
               className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-primary"
             >
               <span className="h-1.5 w-1.5 rounded-full bg-secondary animate-pulse" />
-              v0.13.0 is live
+              v0.14.0 is live
             </motion.p>
 
             <motion.h1

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -58,7 +58,7 @@ export default function Footer() {
               Release
             </p>
             <p className="text-sm font-mono font-medium text-slate-600 dark:text-slate-400">
-              v0.13.0
+              v0.14.0
             </p>
           </div>
         </div>

--- a/apps/web/components/Terminal.tsx
+++ b/apps/web/components/Terminal.tsx
@@ -19,7 +19,7 @@ const installers = [
     label: "PowerShell",
     cmd: 'powershell -ExecutionPolicy Bypass -c "irm https://portal.biuld.app/install.ps1 | iex"',
   },
-  { id: "npm", label: "npm", cmd: "npm install -g @hiverra/portal@0.13.0" },
+  { id: "npm", label: "npm", cmd: "npm install -g @hiverra/portal@0.14.0" },
 ];
 
 export default function InstallTerminal() {
@@ -35,7 +35,7 @@ export default function InstallTerminal() {
           <div className="h-3 w-3 rounded-full border border-green-600 bg-green-500" />
         </div>
         <div className="ml-4 text-[10px] font-bold uppercase tracking-widest text-slate-500 dark:text-slate-400">
-          Install Portal v0.13.0
+          Install Portal v0.14.0
         </div>
       </div>
 

--- a/apps/web/content/(cli)/install.mdx
+++ b/apps/web/content/(cli)/install.mdx
@@ -37,7 +37,7 @@ There are several ways to install Portal. If you just want the tool working quic
   <Tab value="npm package">
     Install globally via npm:
     ```bash
-    npm install -g @hiverra/portal@0.13.0
+    npm install -g @hiverra/portal@0.14.0
     ```
   </Tab>
 </Tabs>

--- a/apps/web/content/(cli)/meta.json
+++ b/apps/web/content/(cli)/meta.json
@@ -7,6 +7,7 @@
     "install",
     "cli-cli",
     "usage",
+    "staging-conflicts",
     "faq",
     "troubleshooting"
   ]

--- a/apps/web/content/(cli)/staging-conflicts.mdx
+++ b/apps/web/content/(cli)/staging-conflicts.mdx
@@ -1,0 +1,31 @@
+---
+title: Staging & Conflict Resolution
+description: How incoming transfers are staged before being moved into place, and how filename conflicts are resolved after the transfer completes.
+openGraph:
+  title: Portal CLI — Staging & Conflict Resolution
+  description: Learn how Portal stages incoming transfers and resolves filename conflicts.
+twitter:
+  title: Portal CLI — Staging & Conflict Resolution
+  description: Learn how Portal stages incoming transfers and resolves filename conflicts.
+---
+
+# Staging & Conflict Resolution
+
+When a transfer arrives, the receiver unpacks everything into a **staging area** at `.portal/stage/<nanos>` inside the target directory, and only moves items into their final location after the stream has fully completed. Two practical effects:
+
+- the progress bar stays clean — conflict prompts never interrupt the transfer
+- the final destination is untouched until the whole transfer has arrived
+
+## Conflict resolution
+
+Filename collisions (an item already exists at the target path) are resolved **after** the transfer, in one consolidated pass. The prompt applies per top-level item — a whole folder is treated as one unit instead of prompting for every file inside it:
+
+- **Overwrite** / **Overwrite All**
+- **Rename** / **Rename All** (writes e.g. `file (1).txt`)
+- **Skip** / **Skip All**
+
+## Interrupted transfers
+
+If the connection drops part-way, the items that had already finished streaming are still moved into the target directory — the receiver prints `Transfer interrupted; recovered N item(s)`. Only the file that was mid-transfer at the moment of the cut is lost.
+
+Staging leftovers from a hard crash (for example the app is killed mid-reconcile) are swept automatically on the next receive once they are older than 24 hours.

--- a/apps/web/content/(cli)/usage.mdx
+++ b/apps/web/content/(cli)/usage.mdx
@@ -119,6 +119,8 @@ If you do **not** pass `--dir`, the receiver resolves the target directory in th
 
 That means receive can still work even when your storage config is incomplete, but it will become interactive.
 
+Incoming transfers are staged before being moved into place, and filename conflicts are resolved after the transfer. See [Staging & Conflict Resolution](/docs/staging-conflicts) for how that works.
+
 ## History is part of the workflow, not an afterthought
 
 Portal keeps transfer history locally in `~/.portal/history.jsonl`, and the records are more detailed than the old docs implied.

--- a/apps/web/content/library/index.mdx
+++ b/apps/web/content/library/index.mdx
@@ -14,7 +14,7 @@ The `pxp` library is a headless, consumer-agnostic Rust implementation of the **
 1. **No Side Effects**
    The library never writes to stdout/stderr or reads from stdin. All logger outputs use the standard `tracing` facade.
 2. **Standard Traits for UI Decoupling**
-   All user-facing behaviors — such as displaying progress bars, printing transfer status messages, and prompting to resolve filename conflicts — are abstracted into traits that the caller implements.
+   All user-facing behaviors — such as displaying progress bars, printing transfer status messages, and resolving filename conflicts — are abstracted into traits that the caller implements.
 3. **Pure Async/Await**
    Built on top of `tokio` for non-blocking network I/O, UDP broadcasting, and filesystem streaming.
 4. **Strongly-Typed Errors**
@@ -28,6 +28,6 @@ The crate is organized into several modules representing protocol stages:
 
 * **`discovery`** — Broadcasts and listens for UDP beacons.
 * **`sender`** — Discovers receivers, establishes TCP handshakes, creates metadata manifests, and streams TAR archives.
-* **`receiver`** — Binds listeners, receives handshake proofs, decodes manifests, prompts for conflict actions, and extracts streams to disk.
+* **`receiver`** — Binds listeners, receives handshake proofs, decodes manifests, stages streams to disk, and reconciles conflicts into the target directory.
 * **`metadata`** — Shared models representing files, directories, manifests, and transfer items.
 * **`error`** — Crate-wide error enum (`PxpError`) and `Result` type alias.

--- a/apps/web/content/library/usage.mdx
+++ b/apps/web/content/library/usage.mdx
@@ -9,7 +9,7 @@ To use the `pxp` library, add it to your `Cargo.toml` dependencies, pinning the 
 
 ```toml
 [dependencies]
-pxp = { version = "0.1.0" }
+pxp = { version = "0.2.0" }
 ```
 
 ---

--- a/apps/web/content/library/usage.mdx
+++ b/apps/web/content/library/usage.mdx
@@ -74,7 +74,7 @@ impl TransferProgress for CustomTransferProgress {
 ```
 
 ### Conflict Resolution
-When writing files to disk, name collisions are intercepted. The receiver queries your implementation of `ConflictResolver` to decide what strategy to use.
+Incoming items are unpacked into a staging dir first, so name collisions are **not** checked while the stream is running. Once the stream has completed, you call `reconcile` with your implementation of `ConflictResolver`; it walks the staged items and resolves any collision against the target path before moving the item into place.
 
 ```rust
 use pxp::{ConflictAction, ConflictResolver, PxpError};
@@ -89,6 +89,8 @@ impl ConflictResolver for CustomConflictResolver {
     }
 }
 ```
+
+Global strategies (`Overwrite All`, `Rename All`, `Skip All`) are remembered by `reconcile` and applied to every remaining conflict, so your resolver is only called once per distinct item.
 
 ---
 
@@ -133,10 +135,10 @@ async fn run_sender(files: Vec<PathBuf>, username: &str) -> Result<(), pxp::PxpE
 
 ## 3. Running a Receiver Session
 
-The receiver binds to a port, accepts the connection, receives the manifest, and processes the incoming data stream.
+The receiver binds to a port, accepts the connection, receives the manifest, stages the incoming data stream, and then reconciles the staged items into the target directory.
 
 ```rust
-use pxp::receiver::{handshake::accept_and_read_manifest, stream::receive_stream};
+use pxp::receiver::{handshake::accept_and_read_manifest, stream::receive_stream, reconcile};
 use std::path::PathBuf;
 
 async fn run_receiver(port: u16, username: String, target_dir: PathBuf) -> Result<(), pxp::PxpError> {
@@ -145,21 +147,25 @@ async fn run_receiver(port: u16, username: String, target_dir: PathBuf) -> Resul
     let socket = handshake.socket;
     let manifest = handshake.manifest;
 
-    // 2. Process data stream and extract files to disk
+    // 2. Process the data stream into a staging dir inside `target_dir`
     let progress = CustomTransferProgress;
-    let resolver = CustomConflictResolver;
-    
-    let (stream_result, summary) = receive_stream(
+
+    let (stream_result, staged, summary) = receive_stream(
         socket,
         manifest.compressed,
         &target_dir,
         manifest.total_files + manifest.total_directories,
         Some(&progress),
-        Some(&resolver),
     ).await;
+
+    // 3. Move staged items into place, resolving any filename conflicts
+    let resolver = CustomConflictResolver;
+    reconcile(&staged, Some(&resolver)).await?;
 
     stream_result?;
     println!("Successfully received {} bytes!", summary.total_bytes);
     Ok(())
 }
 ```
+
+The staged items are returned even when the stream failed part-way, so `reconcile` can still salvage whatever was already received before you report the error.

--- a/apps/web/content/protocol/meta.json
+++ b/apps/web/content/protocol/meta.json
@@ -7,6 +7,7 @@
     "discovery",
     "handshake",
     "manifest",
-    "streaming"
+    "streaming",
+    "streaming-01"
   ]
 }

--- a/apps/web/content/protocol/streaming-01.mdx
+++ b/apps/web/content/protocol/streaming-01.mdx
@@ -1,0 +1,207 @@
+---
+title: PXP-STREAMING 01 (Streaming Spec Draft)
+description: Specification for TAR payload streaming and metadata contracts. Draft 01 clarifies deferred conflict resolution and partial-transfer salvage.
+---
+
+# PXP-STREAMING — Data Streaming
+
+**Parent:** [PXP](overview)  
+**Transport:** TCP  
+**Phase:** 4 of 4  
+**Version:** 01  
+**Status:** Draft Specification  
+**Obsoletes:** [draft-pxp-streaming-00](streaming)
+
+---
+
+## 1. Purpose
+
+After the manifest has been delivered, the sender streams all file and directory data to the receiver over the same TCP connection. PXP-STREAMING defines how items are packaged, how metadata is communicated inline, and how the stream is terminated.
+
+---
+
+## 2. Transport Format
+
+All items are streamed as a single **TAR archive**. The TAR format is used because it supports streaming (no random access required), preserves file names and directory structures, and is universally understood.
+
+### 2.1 Compression
+
+If the manifest field `compressed` is `true`:
+
+```
+TCP Socket → Gzip Frame → TAR Archive → Entries
+```
+
+The entire TAR stream is wrapped in a single Gzip frame. The receiver MUST decompress the stream before parsing TAR entries.
+
+If `compressed` is `false`:
+
+```
+TCP Socket → TAR Archive → Entries
+```
+
+The TAR archive is written directly to the TCP stream with no compression.
+
+The compression decision is made once per transfer and applies to the entire stream. Per-item compression is not supported.
+
+---
+
+## 3. Metadata Contracts
+
+PXP extends the plain TAR format with **metadata contracts** — virtual TAR entries that describe the next real entry. This allows the receiver to know what is coming (file name, size, whether it's a directory) before it arrives.
+
+### 3.1 Contract Entry
+
+A metadata contract is a TAR entry with:
+
+- **Path:** `.portal.meta`
+- **Content:** Bincode-serialized metadata structure
+
+The contract entry MUST appear immediately before the data entry it describes. The receiver MUST NOT write `.portal.meta` to disk.
+
+### 3.2 Contract Schema
+
+The metadata payload is one of:
+
+**For top-level items (files and directories):**
+```
+PxpMeta::Item(TransferItem)
+
+TransferItem = File { filename: string, file_size: u64 }
+             | Directory { dirname: string, total_size: u64 }
+```
+
+**For files nested inside a directory:**
+```
+PxpMeta::NestedFile(FileMetadata { filename: string, file_size: u64 })
+```
+
+### 3.3 Serialization
+
+Metadata contracts MUST be serialized using Bincode (same configuration as the manifest).
+
+---
+
+## 4. Entry Sequence
+
+### 4.1 Top-Level File
+
+```
+[ .portal.meta (Item::File) ] → [ actual-file-data ]
+```
+
+The metadata contract contains the file name and expected size. The next TAR entry contains the file content.
+
+### 4.2 Top-Level Directory
+
+```
+[ .portal.meta (Item::Directory) ] → [ dir-entry ] → [ nested files... ]
+```
+
+The metadata contract contains the directory name and total size. The next TAR entry is the directory itself. Subsequent entries are files within the directory, each preceded by a `PxpMeta::NestedFile` contract.
+
+### 4.3 Nested File (Within a Directory)
+
+```
+[ .portal.meta (NestedFile) ] → [ actual-file-data ]
+```
+
+Same pattern as a top-level file, but the metadata type is `NestedFile` instead of `Item::File`.
+
+---
+
+## 5. Receiver Validation
+
+The receiver MUST enforce the following invariants:
+
+### 5.1 Contract-First Rule
+
+Every data entry MUST be preceded by a `.portal.meta` contract. If a data entry arrives without a preceding contract, the receiver MUST treat this as a protocol error.
+
+### 5.2 Item Count Enforcement
+
+The total number of top-level `Item` contracts received MUST NOT exceed `total_files + total_directories` from the manifest. If more items arrive than declared, the receiver MUST treat this as a security violation and close the connection.
+
+### 5.3 Metadata Consistency
+
+For top-level files, the receiver SHOULD verify:
+- The actual TAR entry filename matches the filename in the contract.
+- The actual TAR entry size matches the `file_size` in the contract.
+
+Mismatches SHOULD be treated as protocol errors.
+
+---
+
+## 6. Conflict Resolution
+
+When the receiver is about to write a file or directory that already exists at the target path, it MUST resolve the conflict before proceeding. The resolution strategy is implementation-defined.
+
+The receiver MAY defer this resolution until after the data stream has completed — for example by staging incoming items first and moving them into place afterwards — as long as conflicts are still resolved before an item is written to its final target path.
+
+PXP defines the following standard conflict actions:
+
+| Action | Behavior |
+|---|---|
+| **Overwrite** | Replace the existing item with the incoming item. Applies to this item only. |
+| **Overwrite All** | Replace existing items for all remaining conflicts. |
+| **Rename** | Write the incoming item with a modified name (e.g. `file (1).txt`). Applies to this item only. |
+| **Rename All** | Rename for all remaining conflicts. |
+| **Skip** | Discard the incoming item. Applies to this item only. |
+| **Skip All** | Skip all remaining conflicts. |
+
+The mechanism for obtaining the user's choice (interactive prompt, config file, API callback) is outside the scope of this specification.
+
+---
+
+## 7. Stream Termination
+
+### 7.1 Normal Completion
+
+The sender signals completion by:
+
+1. Finalizing the TAR archive (writing the two 512-byte zero blocks that mark the end of a TAR stream).
+2. If compressed: shutting down the Gzip encoder (writing the Gzip footer).
+3. Flushing the TCP stream.
+4. Closing the TCP connection.
+
+The receiver detects completion when the TAR entry iterator returns no more entries.
+
+### 7.2 Abnormal Termination
+
+If either side drops the TCP connection before the stream is complete:
+
+- The **receiver** will encounter an unexpected EOF while reading TAR entries or decompressing Gzip data.
+- The **sender** will encounter a broken pipe or connection reset on the next write.
+
+There is no graceful cancellation mechanism. See [Limitations](#8-limitations).
+
+---
+
+## 8. Limitations
+
+### 8.1 No Acknowledgment
+
+The sender does not receive confirmation that the receiver successfully wrote all files. The sender considers the transfer complete after flushing the TCP stream.
+
+### 8.2 No Back-Channel
+
+The receiver has no way to send structured messages back to the sender during the data stream. If the receiver encounters an error (disk full, permission denied, conflict abort), its only option is to drop the TCP connection.
+
+### 8.3 No Cancellation
+
+Neither side can cleanly cancel a transfer in progress. Dropping the connection is the only mechanism, and it produces opaque errors on the other side.
+
+### 8.4 No Resumption
+
+If a transfer is interrupted, it cannot be resumed. The entire transfer must be restarted from the beginning. Items that had already been received are not lost: a conforming receiver may still move the staged items into the target directory before reporting the failure.
+
+> These limitations are acknowledged as areas for future protocol revision. See the [PXP TODO](../TODO.md) for planned improvements.
+
+---
+
+## Revision History
+
+| Version | Changes |
+|---|---|
+| **01** | Clarify that conflict resolution MAY be deferred until after the data stream completes. Clarify that already-received items are preserved when a transfer is interrupted. |
+| **00** | Initial draft. |

--- a/portal-cli/Cargo.toml
+++ b/portal-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hiverra-portal"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["Spectra010s"]
 edition = "2024"
 repository = "https://github.com/Spectra010s/portal"

--- a/portal-cli/src/progress.rs
+++ b/portal-cli/src/progress.rs
@@ -87,6 +87,13 @@ impl ProgressManager {
     pub fn println<S: AsRef<str>>(&self, msg: S) {
         let _ = self.mp.println(msg);
     }
+
+    /// Stops and clears the progress UI. Called once the stream completes, before any
+    /// conflict prompts or final status output, so the terminal stays clean.
+    pub fn finish(&self) {
+        self.top.finish_and_clear();
+        let _ = self.mp.clear();
+    }
 }
 
 pub fn stream_download_with_spinner<R: Read, W: Write>(

--- a/portal-cli/src/receiver/mod.rs
+++ b/portal-cli/src/receiver/mod.rs
@@ -176,17 +176,35 @@ pub async fn start_receiver(port: Option<u16>, dir: &Option<PathBuf>) -> Result<
         prog.set_total_items(total_items as usize);
         trace!("Progress UI initialized with total_items={}", total_items);
 
-        let conflict_resolver = CliConflictResolver;
-        let (stream_result, summary) = pxp::receiver::stream::receive_stream(
+        let (stream_result, staged, summary) = pxp::receiver::stream::receive_stream(
             socket,
             compressed,
             &target_dir,
             total_items,
             Some(&prog as &dyn pxp::TransferProgress),
-            Some(&conflict_resolver as &dyn ConflictResolver),
         )
         .await;
+        // Stop the progress UI before any conflict prompts so the terminal stays clean.
+        prog.finish();
+
+        // Resolve any filename collisions now that the stream is done. This runs on success
+        // AND on a cut connection, so whatever was already staged still lands in the target
+        // dir (same crash-safety as the old per-item finalize behavior).
+        let conflict_resolver = CliConflictResolver;
+        if let Err(e) =
+            pxp::receiver::receive_item::reconcile(&staged, Some(&conflict_resolver as &dyn ConflictResolver))
+                .await
+        {
+            partial_summary = Some(summary);
+            return Err(e.into());
+        }
+
         if let Err(e) = stream_result {
+            println!(
+                "Portal: Transfer interrupted; recovered {} item(s) to '{}'",
+                staged.items.len(),
+                target_dir.display()
+            );
             partial_summary = Some(summary);
             return Err(e.into());
         }
@@ -195,10 +213,10 @@ pub async fn start_receiver(port: Option<u16>, dir: &Option<PathBuf>) -> Result<
             "SUCCESS: Transfer completed. Saved to {}",
             target_dir.display()
         );
-        prog.println(format!(
+        println!(
             "Portal: All item(s) have been received successfully! Saved to '{}'",
             target_dir.display()
-        ));
+        );
 
         // Convert core summary items to CLI history items
         let history_items: Vec<HistoryItem> = summary

--- a/pxp/Cargo.toml
+++ b/pxp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pxp"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Spectra010s"]
 edition = "2024"
 repository = "https://github.com/Spectra010s/portal"

--- a/pxp/src/receiver/mod.rs
+++ b/pxp/src/receiver/mod.rs
@@ -1,4 +1,6 @@
 pub mod handshake;
 pub mod local_ip;
-pub(crate) mod receive_item;
+pub mod receive_item;
 pub mod stream;
+
+pub use receive_item::{reconcile, StagedItem, StagedTransfer};

--- a/pxp/src/receiver/receive_item.rs
+++ b/pxp/src/receiver/receive_item.rs
@@ -7,12 +7,12 @@ use {
     bincode::deserialize,
     std::path::PathBuf,
     tokio::{
-        fs::{File, create_dir_all, remove_dir_all, remove_file, rename, try_exists},
+        fs::{File, create_dir_all, remove_dir, remove_dir_all, remove_file, rename, try_exists},
         io::AsyncRead,
     },
     tokio_stream::StreamExt,
     tokio_tar::Archive,
-    tracing::{debug, error, info, trace, warn},
+    tracing::{debug, error, info, trace},
 };
 
 #[derive(Clone, Copy, PartialEq)]
@@ -23,20 +23,44 @@ enum ConflictStrategy {
     SkipAll,
 }
 
-/// Receives items from the tar archive, validates metadata, and writes to disk.
+/// One top-level item sitting in the staging dir, waiting to be moved into place. We track
+/// both the staged path and the final path because the actual rename only happens at
+/// reconcile time — the stream itself never touches the real destination.
+#[derive(Debug)]
+pub struct StagedItem {
+    pub name: String,
+    pub staged_path: PathBuf,
+    pub final_path: PathBuf,
+    pub is_dir: bool,
+}
+
+/// What the receiver ends up with after streaming: every item unpacked into a private
+/// staging dir, ready for one consolidated reconcile pass. We keep this around even when
+/// the stream dies part-way, so a partial transfer can still be salvaged instead of lost.
+#[derive(Debug)]
+pub struct StagedTransfer {
+    pub items: Vec<StagedItem>,
+    pub staging_dir: PathBuf,
+    pub target_dir: PathBuf,
+}
+
+/// Receives items from the tar archive, validates metadata, and writes them into a private
+/// staging dir (so conflicts never interrupt the stream). Appends each completed top-level
+/// item to `staged_items`, which the caller can reconcile into the target dir even when the
+/// stream fails part-way through.
 pub async fn receive_item<R>(
     archive: &mut Archive<R>,
     target_dir: &PathBuf,
+    staging_dir: &PathBuf,
     total_items: u32,
     progress: Option<&dyn TransferProgress>,
-    conflict_resolver: Option<&dyn ConflictResolver>,
     summary: &mut ReceiveSummary,
+    staged_items: &mut Vec<StagedItem>,
 ) -> Result<()>
 where
     R: AsyncRead + Unpin + Send + 'static,
 {
     let mut contract: Option<PxpMeta> = None;
-    let mut global_strategy = ConflictStrategy::Prompt;
     let mut items_processed: u32 = 0;
     let mut active_dir_progress: Option<Box<dyn crate::ItemProgress>> = None;
     let mut pending_dir_success: Option<String> = None;
@@ -161,8 +185,6 @@ where
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "unknown".into());
 
-        let temp_path = target_dir.join(format!(".tmp_{}_portal", item_name));
-
         // We clean and validate the incoming path by stripping out any weird components 
         // (like `..` or absolute path roots). This is a crucial security measure to prevent 
         // "Zip Slip" style attacks where a malicious sender tries to write outside the target dir.
@@ -170,79 +192,24 @@ where
             .components()
             .filter(|c| matches!(c, std::path::Component::Normal(_)))
             .collect::<PathBuf>();
-        let mut final_path = target_dir.join(safe_path);
+        let staged_path = staging_dir.join(&safe_path);
+        let final_path = target_dir.join(safe_path);
+        let is_top_level = matches!(&meta, PxpMeta::Item(_));
         trace!(
-            "Resolved extraction paths: temp={:?}, final={:?}",
-            temp_path, final_path
+            "Resolved extraction paths: staged={:?}, final={:?}",
+            staged_path, final_path
         );
 
-        // pre-check existence
-        let final_exists = try_exists(&final_path).await?;
-        let temp_exists = try_exists(&temp_path).await?;
-
-        // handle conflict
-        // If the file already exists on disk, we have a collision. Rather than blindly overwriting,
-        // we intercept it and ask the resolver (which might prompt the user). 
-        // We cache global strategies like OverwriteAll, RenameAll, or SkipAll so we don't have to 
-        // keep bugging the user for every single file in a massive directory.
-        if final_exists && global_strategy != ConflictStrategy::OverwriteAll {
-            warn!("Conflict detected for path: {:?}", final_path);
-            if global_strategy == ConflictStrategy::SkipAll {
-                debug!("Strategy SkipAll: skipping {:?}", item_name);
-                continue;
-            } else if global_strategy == ConflictStrategy::RenameAll {
-                final_path = get_unused_path(final_path).await;
-                debug!("Strategy RenameAll: new path {:?}", final_path);
-            } else if let Some(resolver) = conflict_resolver {
-                let action = resolver.resolve(&item_name)?;
-                trace!("Conflict resolver returned: {:?}", action);
-
-                match action {
-                    ConflictAction::Overwrite => info!("Chose to overwrite {:?}", item_name),
-                    ConflictAction::OverwriteAll => {
-                        info!("Enabled Overwrite All strategy");
-                        global_strategy = ConflictStrategy::OverwriteAll;
-                    }
-                    ConflictAction::Rename => {
-                        final_path = get_unused_path(final_path).await;
-                        info!("Chose to rename to {:?}", final_path);
-                    }
-                    ConflictAction::RenameAll => {
-                        info!("Enabled Rename All strategy");
-                        global_strategy = ConflictStrategy::RenameAll;
-                        final_path = get_unused_path(final_path).await;
-                    }
-                    ConflictAction::Skip => {
-                        info!("Skipped item {:?}", item_name);
-                        continue;
-                    }
-                    ConflictAction::SkipAll => {
-                        info!("Enabled Skip All strategy");
-                        global_strategy = ConflictStrategy::SkipAll;
-                        continue;
-                    }
-                }
-            } else {
-                // No conflict resolver provided, default to overwrite
-                info!("No conflict resolver: defaulting to overwrite {:?}", item_name);
-            }
-        }
-
-        // prepare temp folder
-        trace!("Cleaning/Creating temp directory: {:?}", temp_path);
-        if temp_exists {
-            let _ = remove_dir_all(&temp_path).await;
-        }
-        create_dir_all(&temp_path).await?;
-
+        // Unpack into the private staging dir. Nothing can collide inside a fresh staging
+        // dir, so no prompts interrupt the progress UI. Conflicts are resolved afterwards
+        // by `reconcile` once the stream has fully completed. The whole staging dir is the
+        // temp area now — no more per-item `.tmp_*_portal` dance.
         if !is_dir {
-            trace!(
-                "Unpacking file to temp storage: {}/{}",
-                temp_path.display(),
-                item_name
-            );
-            let file_in_temp = temp_path.join(&item_name);
-            let outfile = File::create(&file_in_temp).await?;
+            trace!("Unpacking file to staging: {}", staged_path.display());
+            if let Some(parent) = staged_path.parent() {
+                create_dir_all(parent).await?;
+            }
+            let outfile = File::create(&staged_path).await?;
 
             if let Some(prog) = entry_item_progress.take() {
                 let mut writer = prog.wrap_write(Box::new(outfile));
@@ -256,28 +223,23 @@ where
                 let mut outfile = outfile;
                 tokio::io::copy(&mut entry, &mut outfile).await?;
             }
+        } else {
+            trace!("Creating staging directory: {}", staged_path.display());
+            create_dir_all(&staged_path).await?;
         }
 
-        // move to final location
-        trace!("Moving from temp to final destination: {:?}", final_path);
-        if let Some(parent) = final_path.parent() {
-            create_dir_all(parent).await?;
+        // Only top-level items get recorded. Nested files ride along inside their parent
+        // folder's staged dir, so conflict resolution happens once per folder — we treat a
+        // whole folder as one unit instead of prompting for every single file in it.
+        if is_top_level {
+            staged_items.push(StagedItem {
+                name: item_name.clone(),
+                staged_path: staged_path.clone(),
+                final_path,
+                is_dir,
+            });
+            debug!("Item staged at {:?}", staged_path);
         }
-        if !is_dir {
-            if final_exists {
-                trace!("Overwriting existing file at {:?}", final_path);
-                let _ = remove_file(&final_path).await;
-            }
-            rename(temp_path.join(item_name), &final_path).await?;
-            let _ = remove_dir_all(&temp_path).await;
-        } else {
-            if final_exists {
-                trace!("Overwriting existing directory at {:?}", final_path);
-                let _ = remove_dir_all(&final_path).await;
-            }
-            rename(&temp_path, &final_path).await?;
-        }
-        debug!("Item finalized at target path: {:?}", final_path);
 
         // validate metadata
         match meta {
@@ -373,6 +335,129 @@ where
         )));
     }
     info!("All {} items received and verified.", items_processed);
+    Ok(())
+}
+
+/// Moves staged items into the target dir, resolving any filename collisions now that the
+/// stream has fully completed — so conflict prompts never interrupt the progress UI.
+///
+/// Strategy memoization is shared across items: choosing "Overwrite All", "Rename All" or
+/// "Skip All" applies to every remaining item without prompting again.
+pub async fn reconcile(
+    staged: &StagedTransfer,
+    conflict_resolver: Option<&dyn ConflictResolver>,
+) -> Result<()> {
+    let mut global_strategy = ConflictStrategy::Prompt;
+
+    for item in &staged.items {
+        let final_exists = try_exists(&item.final_path).await?;
+        let mut final_path = item.final_path.clone();
+
+        if final_exists && global_strategy != ConflictStrategy::OverwriteAll {
+            match global_strategy {
+                ConflictStrategy::SkipAll => {
+                    debug!("Strategy SkipAll: skipping {:?}", item.name);
+                    remove_staged_item(item).await?;
+                    continue;
+                }
+                ConflictStrategy::RenameAll => {
+                    final_path = get_unused_path(final_path).await;
+                    debug!("Strategy RenameAll: new path {:?}", final_path);
+                }
+                _ => {
+                    if let Some(resolver) = conflict_resolver {
+                        let action = resolver.resolve(&item.name)?;
+                        trace!("Conflict resolver returned: {:?}", action);
+
+                        match action {
+                            ConflictAction::Overwrite => {
+                                info!("Chose to overwrite {:?}", item.name)
+                            }
+                            ConflictAction::OverwriteAll => {
+                                info!("Enabled Overwrite All strategy");
+                                global_strategy = ConflictStrategy::OverwriteAll;
+                            }
+                            ConflictAction::Rename => {
+                                final_path = get_unused_path(final_path).await;
+                                info!("Chose to rename to {:?}", final_path);
+                            }
+                            ConflictAction::RenameAll => {
+                                info!("Enabled Rename All strategy");
+                                global_strategy = ConflictStrategy::RenameAll;
+                                final_path = get_unused_path(final_path).await;
+                            }
+                            ConflictAction::Skip => {
+                                info!("Skipped item {:?}", item.name);
+                                remove_staged_item(item).await?;
+                                continue;
+                            }
+                            ConflictAction::SkipAll => {
+                                info!("Enabled Skip All strategy");
+                                global_strategy = ConflictStrategy::SkipAll;
+                                remove_staged_item(item).await?;
+                                continue;
+                            }
+                        }
+                    } else {
+                        // No conflict resolver provided, default to overwrite
+                        info!(
+                            "No conflict resolver: defaulting to overwrite {:?}",
+                            item.name
+                        );
+                    }
+                }
+            }
+        }
+
+        // Move the staged item into its final location. Staging lives inside the target
+        // dir, so this is always a same-filesystem rename (fast even on external drives).
+        if let Some(parent) = final_path.parent() {
+            create_dir_all(parent).await?;
+        }
+        if !item.is_dir {
+            if try_exists(&final_path).await? {
+                trace!("Overwriting existing file at {:?}", final_path);
+                let _ = remove_file(&final_path).await;
+            }
+            rename(&item.staged_path, &final_path).await?;
+        } else {
+            if try_exists(&final_path).await? {
+                trace!("Overwriting existing directory at {:?}", final_path);
+                let _ = remove_dir_all(&final_path).await;
+            }
+            rename(&item.staged_path, &final_path).await?;
+        }
+        debug!("Item reconciled at target path: {:?}", final_path);
+    }
+
+    // Clean up the staging root now that every item has been moved or skipped,
+    // then prune the now-empty `.portal/stage` and `.portal` parents.
+    // Remove only the (now-empty) parents. We deliberately use empty-only `remove_dir`
+    // rather than `remove_dir_all`: a concurrent transfer could still be staging into its
+    // own subdir, and we don't want to nuke a sibling's in-progress work.
+    let _ = remove_dir_all(&staged.staging_dir).await;
+    if let Some(stage) = staged.staging_dir.parent() {
+        let _ = remove_dir(stage).await;
+        if let Some(portal) = stage.parent() {
+            let _ = remove_dir(portal).await;
+        }
+    }
+    info!(
+        "Reconcile complete: {} item(s) moved into '{}'",
+        staged.items.len(),
+        staged.target_dir.display()
+    );
+    Ok(())
+}
+
+/// Deletes a skipped item from staging so it doesn't linger and get mistaken for a
+/// completed file later (and so the final staging-dir cleanup stays trivial).
+async fn remove_staged_item(item: &StagedItem) -> Result<()> {
+    if item.is_dir {
+        let _ = remove_dir_all(&item.staged_path).await;
+    } else {
+        let _ = remove_file(&item.staged_path).await;
+    }
     Ok(())
 }
 

--- a/pxp/src/receiver/stream.rs
+++ b/pxp/src/receiver/stream.rs
@@ -1,28 +1,32 @@
 use {
     crate::{
         metadata::ReceiveSummary,
-        receiver::receive_item::receive_item,
-        ConflictResolver, TransferProgress,
+        receiver::receive_item::{receive_item, StagedItem, StagedTransfer},
+        TransferProgress,
     },
     crate::error::Result,
     async_compression::tokio::bufread::GzipDecoder,
-    std::path::PathBuf,
+    std::{
+        path::{Path, PathBuf},
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    },
     tokio::{
         io::{AsyncRead, BufReader},
         net::TcpStream,
     },
     tokio_tar::Archive,
-    tracing::{debug, trace},
+    tracing::{debug, trace, warn},
 };
 
+/// Returns the stream outcome, the staged items (even when the stream failed part-way,
+/// so partial transfers can still be reconciled into the target dir), and the summary.
 pub async fn receive_stream(
     socket: TcpStream,
     compressed: bool,
     target_dir: &PathBuf,
     total_items: u32,
     progress: Option<&dyn TransferProgress>,
-    conflict_resolver: Option<&dyn ConflictResolver>,
-) -> (Result<()>, ReceiveSummary) {
+) -> (Result<()>, StagedTransfer, ReceiveSummary) {
     let mut summary = ReceiveSummary {
         items: Vec::new(),
         total_bytes: 0,
@@ -36,17 +40,45 @@ pub async fn receive_stream(
     };
     let mut archive = Archive::new(reader);
 
-    if let Err(err) = receive_item(
+    // Clean up stale staging dirs left behind by interrupted runs so they never
+    // accumulate. Recent ones are kept in case another transfer is still active.
+    sweep_stale_staging(target_dir).await;
+
+    // The staging dir lives inside the target dir so the final reconcile move is always
+    // a same-filesystem rename, even when the target is an external drive. All portal
+    // artifacts are grouped under `.portal/stage/`, one subdir per transfer.
+    let staging_dir = target_dir
+        .join(".portal")
+        .join("stage")
+        .join(format!(
+            "{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+
+    let mut staged_items: Vec<StagedItem> = Vec::new();
+    let result = receive_item(
         &mut archive,
         target_dir,
+        &staging_dir,
         total_items,
         progress,
-        conflict_resolver,
         &mut summary,
+        &mut staged_items,
     )
-    .await
-    {
-        return (Err(err), summary);
+    .await;
+
+    if let Err(err) = result {
+        // Connection cut or protocol error. The items that already finished staging are
+        // kept so the caller can still move them into the target dir.
+        let staged = StagedTransfer {
+            items: staged_items,
+            staging_dir,
+            target_dir: target_dir.clone(),
+        };
+        return (Err(err), staged, summary);
     }
     trace!("receive_item recursive loop completed.");
 
@@ -54,5 +86,50 @@ pub async fn receive_stream(
     let _reader = archive.into_inner();
     trace!("Archive reader recovered.");
 
-    (Ok(()), summary)
+    let staged = StagedTransfer {
+        items: staged_items,
+        staging_dir,
+        target_dir: target_dir.clone(),
+    };
+    (Ok(()), staged, summary)
+}
+
+/// Removes per-transfer staging subdirs under `.portal/stage/` that are older than 24h,
+/// then prunes the now-empty `.portal/stage` and `.portal` parents.
+async fn sweep_stale_staging(target_dir: &Path) {
+    let stage_dir = target_dir.join(".portal").join("stage");
+    if let Ok(read_dir) = std::fs::read_dir(&stage_dir) {
+        let now = SystemTime::now();
+        for entry in read_dir.flatten() {
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let stale = entry
+                .metadata()
+                .ok()
+                .and_then(|m| m.modified().ok())
+                .and_then(|m| now.duration_since(m).ok())
+                .map(|age| age > Duration::from_secs(24 * 60 * 60))
+                .unwrap_or(false);
+            if stale {
+                warn!(
+                    "Sweeping stale staging dir '{}' left by a previous run",
+                    entry.path().display()
+                );
+                let _ = std::fs::remove_dir_all(entry.path());
+            }
+        }
+    }
+    prune_staging_parents(&stage_dir).await;
+}
+
+/// Removes the (now-empty) `.portal/stage` and `.portal` dirs if present. No-ops when
+/// they still contain content (e.g. an active sibling transfer).
+async fn prune_staging_parents(staging_dir: &Path) {
+    if let Some(stage) = staging_dir.parent() {
+        let _ = tokio::fs::remove_dir(stage).await;
+        if let Some(portal) = stage.parent() {
+            let _ = tokio::fs::remove_dir(portal).await;
+        }
+    }
 }

--- a/spec/draft-pxp-streaming-01.md
+++ b/spec/draft-pxp-streaming-01.md
@@ -1,0 +1,202 @@
+# PXP-STREAMING — Data Streaming
+
+**Parent:** [PXP](draft-pxp-overview-00.md)  
+**Transport:** TCP  
+**Phase:** 4 of 4  
+**Version:** 01  
+**Status:** Draft Specification  
+**Obsoletes:** [draft-pxp-streaming-00](draft-pxp-streaming-00.md)
+
+---
+
+## 1. Purpose
+
+After the manifest has been delivered, the sender streams all file and directory data to the receiver over the same TCP connection. PXP-STREAMING defines how items are packaged, how metadata is communicated inline, and how the stream is terminated.
+
+---
+
+## 2. Transport Format
+
+All items are streamed as a single **TAR archive**. The TAR format is used because it supports streaming (no random access required), preserves file names and directory structures, and is universally understood.
+
+### 2.1 Compression
+
+If the manifest field `compressed` is `true`:
+
+```
+TCP Socket → Gzip Frame → TAR Archive → Entries
+```
+
+The entire TAR stream is wrapped in a single Gzip frame. The receiver MUST decompress the stream before parsing TAR entries.
+
+If `compressed` is `false`:
+
+```
+TCP Socket → TAR Archive → Entries
+```
+
+The TAR archive is written directly to the TCP stream with no compression.
+
+The compression decision is made once per transfer and applies to the entire stream. Per-item compression is not supported.
+
+---
+
+## 3. Metadata Contracts
+
+PXP extends the plain TAR format with **metadata contracts** — virtual TAR entries that describe the next real entry. This allows the receiver to know what is coming (file name, size, whether it's a directory) before it arrives.
+
+### 3.1 Contract Entry
+
+A metadata contract is a TAR entry with:
+
+- **Path:** `.portal.meta`
+- **Content:** Bincode-serialized metadata structure
+
+The contract entry MUST appear immediately before the data entry it describes. The receiver MUST NOT write `.portal.meta` to disk.
+
+### 3.2 Contract Schema
+
+The metadata payload is one of:
+
+**For top-level items (files and directories):**
+```
+PxpMeta::Item(TransferItem)
+
+TransferItem = File { filename: string, file_size: u64 }
+             | Directory { dirname: string, total_size: u64 }
+```
+
+**For files nested inside a directory:**
+```
+PxpMeta::NestedFile(FileMetadata { filename: string, file_size: u64 })
+```
+
+### 3.3 Serialization
+
+Metadata contracts MUST be serialized using Bincode (same configuration as the manifest).
+
+---
+
+## 4. Entry Sequence
+
+### 4.1 Top-Level File
+
+```
+[ .portal.meta (Item::File) ] → [ actual-file-data ]
+```
+
+The metadata contract contains the file name and expected size. The next TAR entry contains the file content.
+
+### 4.2 Top-Level Directory
+
+```
+[ .portal.meta (Item::Directory) ] → [ dir-entry ] → [ nested files... ]
+```
+
+The metadata contract contains the directory name and total size. The next TAR entry is the directory itself. Subsequent entries are files within the directory, each preceded by a `PxpMeta::NestedFile` contract.
+
+### 4.3 Nested File (Within a Directory)
+
+```
+[ .portal.meta (NestedFile) ] → [ actual-file-data ]
+```
+
+Same pattern as a top-level file, but the metadata type is `NestedFile` instead of `Item::File`.
+
+---
+
+## 5. Receiver Validation
+
+The receiver MUST enforce the following invariants:
+
+### 5.1 Contract-First Rule
+
+Every data entry MUST be preceded by a `.portal.meta` contract. If a data entry arrives without a preceding contract, the receiver MUST treat this as a protocol error.
+
+### 5.2 Item Count Enforcement
+
+The total number of top-level `Item` contracts received MUST NOT exceed `total_files + total_directories` from the manifest. If more items arrive than declared, the receiver MUST treat this as a security violation and close the connection.
+
+### 5.3 Metadata Consistency
+
+For top-level files, the receiver SHOULD verify:
+- The actual TAR entry filename matches the filename in the contract.
+- The actual TAR entry size matches the `file_size` in the contract.
+
+Mismatches SHOULD be treated as protocol errors.
+
+---
+
+## 6. Conflict Resolution
+
+When the receiver is about to write a file or directory that already exists at the target path, it MUST resolve the conflict before proceeding. The resolution strategy is implementation-defined.
+
+The receiver MAY defer this resolution until after the data stream has completed — for example by staging incoming items first and moving them into place afterwards — as long as conflicts are still resolved before an item is written to its final target path.
+
+PXP defines the following standard conflict actions:
+
+| Action | Behavior |
+|---|---|
+| **Overwrite** | Replace the existing item with the incoming item. Applies to this item only. |
+| **Overwrite All** | Replace existing items for all remaining conflicts. |
+| **Rename** | Write the incoming item with a modified name (e.g. `file (1).txt`). Applies to this item only. |
+| **Rename All** | Rename for all remaining conflicts. |
+| **Skip** | Discard the incoming item. Applies to this item only. |
+| **Skip All** | Skip all remaining conflicts. |
+
+The mechanism for obtaining the user's choice (interactive prompt, config file, API callback) is outside the scope of this specification.
+
+---
+
+## 7. Stream Termination
+
+### 7.1 Normal Completion
+
+The sender signals completion by:
+
+1. Finalizing the TAR archive (writing the two 512-byte zero blocks that mark the end of a TAR stream).
+2. If compressed: shutting down the Gzip encoder (writing the Gzip footer).
+3. Flushing the TCP stream.
+4. Closing the TCP connection.
+
+The receiver detects completion when the TAR entry iterator returns no more entries.
+
+### 7.2 Abnormal Termination
+
+If either side drops the TCP connection before the stream is complete:
+
+- The **receiver** will encounter an unexpected EOF while reading TAR entries or decompressing Gzip data.
+- The **sender** will encounter a broken pipe or connection reset on the next write.
+
+There is no graceful cancellation mechanism. See [Limitations](#8-limitations).
+
+---
+
+## 8. Limitations
+
+### 8.1 No Acknowledgment
+
+The sender does not receive confirmation that the receiver successfully wrote all files. The sender considers the transfer complete after flushing the TCP stream.
+
+### 8.2 No Back-Channel
+
+The receiver has no way to send structured messages back to the sender during the data stream. If the receiver encounters an error (disk full, permission denied, conflict abort), its only option is to drop the TCP connection.
+
+### 8.3 No Cancellation
+
+Neither side can cleanly cancel a transfer in progress. Dropping the connection is the only mechanism, and it produces opaque errors on the other side.
+
+### 8.4 No Resumption
+
+If a transfer is interrupted, it cannot be resumed. The entire transfer must be restarted from the beginning. Items that had already been received are not lost: a conforming receiver may still move the staged items into the target directory before reporting the failure.
+
+> These limitations are acknowledged as areas for future protocol revision. See the [PXP TODO](../TODO.md) for planned improvements.
+
+---
+
+## Revision History
+
+| Version | Changes |
+|---|---|
+| **01** | Clarify that conflict resolution MAY be deferred until after the data stream completes. Clarify that already-received items are preserved when a transfer is interrupted. |
+| **00** | Initial draft. |


### PR DESCRIPTION
## What

Stage incoming items into `--dir/.portal/stage/<nanos>` so conflict prompts never interrupt the transfer, then reconcile (move) them into place after the stream completes. On a cut connection the already-staged items are still reconciled, so partial transfers are salvaged instead of lost.

## Changes

- `pxp`: `receive_item` writes into a staging dir and appends `StagedItem` records; new `reconcile()` moves items into the target dir with memoized conflict strategies; `receive_stream` returns `(Result, StagedTransfer, ReceiveSummary)` and sweeps stale staging dirs (24h TTL).
- `portal-cli`: clears the progress UI before conflict prompts; runs `reconcile` on success and on interruption.
- Docs: CLI staging/conflict page, library guide updated for the new API, PXP-STREAMING draft 01 (spec + docs mirror).